### PR TITLE
Pin `org.eclipse.jgit:org.eclipse.jgit` version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            // Fix https://github.com/jreleaser/jreleaser/issues/1643
+            force 'org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r'
+        }
+    }
+}
+
 plugins {
     id 'base'
     id 'org.jreleaser' version "1.24.0"


### PR DESCRIPTION
## 💡 What does this PR do?
This pull request pins the version of `org.eclipse.jgit:org.eclipse.jgit` to resolve the incompatibility between JReleaser and Spotless, as also observed [here](https://github.com/entur/oidc-auth-resource-server/pull/60).

## 🔧 List of changes
- Pins `org.eclipse.jgit:org.eclipse.jgit` version

## 📋 Checklist
- [x] Am familiar with the release pipeline for this project
- [ ] I have updated relevant developer documentation
- [ ] I have updated relevant user documentation
- [ ] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes